### PR TITLE
Unidad 08 - jtapia

### DIFF
--- a/unidad04/U4_parte_01.yaml
+++ b/unidad04/U4_parte_01.yaml
@@ -33,4 +33,5 @@ spec:
         - name: hotels
           image: ghcr.io/go-elevate/k8s4arch-hotels:monolith
           ports:
-            - containerPort: 80
+            - containerPort: 80 
+            

--- a/unidad04/U4_parte_01.yaml
+++ b/unidad04/U4_parte_01.yaml
@@ -33,4 +33,4 @@ spec:
         - name: hotels
           image: ghcr.io/go-elevate/k8s4arch-hotels:monolith
           ports:
-            - containerPort: 80 
+            - containerPort: 80

--- a/unidad05/U5_parte01.yaml
+++ b/unidad05/U5_parte01.yaml
@@ -72,3 +72,4 @@ spec:
           envFrom:
             - configMapRef:
                 name: hotels-config-env
+                

--- a/unidad05/U5_parte01.yaml
+++ b/unidad05/U5_parte01.yaml
@@ -73,3 +73,4 @@ spec:
             - configMapRef:
                 name: hotels-config-env
                 
+                

--- a/unidad08/U8_parte_01.yaml
+++ b/unidad08/U8_parte_01.yaml
@@ -38,7 +38,8 @@ metadata:
   name: hotels-backend-pvc
   namespace: hotels-prod
 spec:
-  storageClassName: hostpath
+  #storageClassName: hostpath
+  storageClassName: microk8s-hostpath
   accessModes:
   - ReadWriteMany
   resources:


### PR DESCRIPTION
Fix sobre storageClassName del PVC, 
Se reemplazó el valor de storageClassName "hostpath" que es el válido para k8s de Docker desktop , el que vengo utilizando, por   "microk8s-hostpath"  que es el válido para microk8s , para la validación del ejercicio.
